### PR TITLE
Set option to hide pagination links in API responses

### DIFF
--- a/src/Traits/APIResponseTrait.php
+++ b/src/Traits/APIResponseTrait.php
@@ -247,6 +247,11 @@ trait APIResponseTrait
                 ],
             ];
 
+        // Remove pagination links
+        if (config('response.hideMetaPaginationLinks', true) && isset($extra['pagination'])) {
+            unset($extra['pagination']['links']);
+        }
+
         return $this->apiRawResponse($data, null, $extra);
     }
 

--- a/src/config/response.php
+++ b/src/config/response.php
@@ -112,6 +112,9 @@ return [
     // Return default error codes if error code is set to null
     'returnDefaultErrorCodes' => true,
 
+    // Hide next, previous links in meta
+    'hideMetaPaginationLinks' => true,
+
     // Set error codes output default value for built-in functions
     'errorCodesDefaults' => [
         'apiNotFound' => 'RESOURCE_NOT_FOUND',


### PR DESCRIPTION
Added a configuration setting to hide pagination links in the meta section of API responses. Updated the APIResponseTrait to respect this setting by removing the 'links' field from pagination data when enabled.