### PR TITLE
Standardize exception handling and JSON error responses

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -69,14 +69,30 @@ class Handler extends ExceptionHandler
      *
      * @param Request $request
      * @param Throwable $e
-     * @return \Symfony\Component\HttpFoundation\Response
-     *
+     * @return JsonResponse|StreamedJsonResponse|\Symfony\Component\HttpFoundation\Response
      * @throws Throwable
      */
-    public function render($request, Throwable $e): \Symfony\Component\HttpFoundation\Response
+    public function render($request, Throwable $e)
     {
         // Check if request expects json
         if($request->expectsJson()){
+            // Check if app debug is enabled to return traces
+            if (config('app.debug')) {
+                // Set data
+                $data = collect([
+                    'exception' => get_class($e),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                    'trace' => $e->getTrace(),
+                ]);
+
+                return $this->apiResponse([
+                    'status_code' => $e->getCode(),
+                    'message' => $e->getMessage(),
+                    'data' => $data,
+                ]);
+            }
+
             // Not found http exception OR Method not allowed http exception
             if ($e instanceof NotFoundHttpException || $e instanceof MethodNotAllowedHttpException) {
                 return $this->apiNotFound();
@@ -89,23 +105,6 @@ class Handler extends ExceptionHandler
 
             // Server error
             if (($e instanceof Error || $e instanceof ParseError)) {
-                // Check if app debug is enabled to return traces
-                if (config('app.debug')) {
-                    // Set data
-                    $data = new Collection([
-                        'exception' => get_class($e),
-                        'file' => $e->getFile(),
-                        'line' => $e->getLine(),
-                        'trace' => $e->getTrace(),
-                    ]);
-
-                    return $this->apiResponse([
-                        'type' => 'server error',
-                        'message' => $e->getMessage(),
-                        'data' => $data,
-                    ]);
-                }
-
                 // Return server error response
                 return $this->apiResponse([
                     'type' => 'server error'

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -75,44 +75,42 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Throwable $e): \Symfony\Component\HttpFoundation\Response
     {
-        // Not found http exception
-        if ($e instanceof NotFoundHttpException && $request->wantsJson()) {
-            return $this->apiResponse(['type' => 'not found']);
-        }
-
-        // Method not allowed http exception
-        if ($e instanceof MethodNotAllowedHttpException && $request->wantsJson()) {
-            return $this->apiResponse(['type' => 'not found']);
-        }
-
-        // Status code 0
-        if ($e instanceof HttpException && $request->wantsJson()) {
-            return $this->apiBadRequest();
-        }
-
-        // Server error
-        if (($e instanceof Error || $e instanceof ParseError) && $request->wantsJson()) {
-            // Check if app debug is enabled to return traces
-            if (config('app.debug')) {
-                // Set data
-                $data = new Collection([
-                    'exception' => get_class($e),
-                    'file' => $e->getFile(),
-                    'line' => $e->getLine(),
-                    'trace' => $e->getTrace(),
-                ]);
-
-                return $this->apiResponse([
-                    'type' => 'server error',
-                    'message' => $e->getMessage(),
-                    'data' => $data,
-                ]);
+        // Check if request expects json
+        if($request->expectsJson()){
+            // Not found http exception OR Method not allowed http exception
+            if ($e instanceof NotFoundHttpException || $e instanceof MethodNotAllowedHttpException) {
+                return $this->apiNotFound();
             }
 
-            // Return server error response
-            return $this->apiResponse([
-                'type' => 'server error'
-            ]);
+            // Status code 0
+            if ($e instanceof HttpException) {
+                return $this->apiBadRequest();
+            }
+
+            // Server error
+            if (($e instanceof Error || $e instanceof ParseError)) {
+                // Check if app debug is enabled to return traces
+                if (config('app.debug')) {
+                    // Set data
+                    $data = new Collection([
+                        'exception' => get_class($e),
+                        'file' => $e->getFile(),
+                        'line' => $e->getLine(),
+                        'trace' => $e->getTrace(),
+                    ]);
+
+                    return $this->apiResponse([
+                        'type' => 'server error',
+                        'message' => $e->getMessage(),
+                        'data' => $data,
+                    ]);
+                }
+
+                // Return server error response
+                return $this->apiResponse([
+                    'type' => 'server error'
+                ]);
+            }
         }
 
         return parent::render($request, $e);

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -4,6 +4,7 @@ namespace MA\LaravelApiResponse\Exceptions;
 
 use Error;
 use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -87,14 +88,14 @@ class Handler extends ExceptionHandler
                 ]);
 
                 return $this->apiResponse([
-                    'status_code' => $e->getCode(),
+                    'status_code' => 500,
                     'message' => $e->getMessage(),
                     'data' => $data,
                 ]);
             }
 
             // Not found http exception OR Method not allowed http exception
-            if ($e instanceof NotFoundHttpException || $e instanceof MethodNotAllowedHttpException) {
+            if ($e instanceof NotFoundHttpException || $e instanceof MethodNotAllowedHttpException || $e instanceof ModelNotFoundException) {
                 return $this->apiNotFound();
             }
 

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -77,7 +77,7 @@ class Handler extends ExceptionHandler
         // Check if request expects json
         if($request->expectsJson()){
             // Check if app debug is enabled to return traces
-            if (config('app.debug')) {
+            if ((bool)config('app.debug')) {
                 // Set data
                 $data = collect([
                     'exception' => get_class($e),

--- a/src/Exceptions/LumenHandler.php
+++ b/src/Exceptions/LumenHandler.php
@@ -82,7 +82,7 @@ class LumenHandler extends ExceptionHandler
         // Check if request expects json
         if ($request->expectsJson()) {
             // Check if app debug is enabled to return traces
-            if (config('app.debug')) {
+            if ((bool)config('app.debug')) {
                 // Set data
                 $data = collect([
                     'exception' => get_class($e),

--- a/src/Exceptions/LumenHandler.php
+++ b/src/Exceptions/LumenHandler.php
@@ -7,12 +7,11 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Validation\ValidationException;
-use Laravel\Lumen\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
+use Laravel\Lumen\Exceptions\Handler as ExceptionHandler;
 use MA\LaravelApiResponse\Traits\APIResponseTrait;
 use ParseError;
 use Psr\Log\LogLevel;
@@ -81,44 +80,42 @@ class LumenHandler extends ExceptionHandler
      */
     public function render($request, Throwable $e): \Symfony\Component\HttpFoundation\Response
     {
-        // Not found http exception
-        if ($e instanceof NotFoundHttpException && $request->wantsJson()) {
-            return $this->apiResponse(['type' => 'not found']);
-        }
-
-        // Method not allowed http exception
-        if ($e instanceof MethodNotAllowedHttpException && $request->wantsJson()) {
-            return $this->apiResponse(['type' => 'not found']);
-        }
-
-        // Status code 0
-        if ($e instanceof HttpException && $request->wantsJson()) {
-            return $this->apiBadRequest();
-        }
-
-        // Server error
-        if (($e instanceof Error || $e instanceof ParseError) && $request->wantsJson()) {
-            // Check if app debug is enabled to return traces
-            if (config('app.debug')) {
-                // Set data
-                $data = new Collection([
-                    'exception' => get_class($e),
-                    'file' => $e->getFile(),
-                    'line' => $e->getLine(),
-                    'trace' => $e->getTrace(),
-                ]);
-
-                return $this->apiResponse([
-                    'type' => 'server error',
-                    'message' => $e->getMessage(),
-                    'data' => $data,
-                ]);
+        // Check if request expects json
+        if ($request->expectsJson()) {
+            // Not found http exception OR Method not allowed http exception
+            if ($e instanceof NotFoundHttpException || $e instanceof MethodNotAllowedHttpException) {
+                return $this->apiNotFound();
             }
 
-            // Return server error response
-            return $this->apiResponse([
-                'type' => 'server error'
-            ]);
+            // Status code 0
+            if ($e instanceof HttpException) {
+                return $this->apiBadRequest();
+            }
+
+            // Server error
+            if (($e instanceof Error || $e instanceof ParseError)) {
+                // Check if app debug is enabled to return traces
+                if (config('app.debug')) {
+                    // Set data
+                    $data = new Collection([
+                        'exception' => get_class($e),
+                        'file' => $e->getFile(),
+                        'line' => $e->getLine(),
+                        'trace' => $e->getTrace(),
+                    ]);
+
+                    return $this->apiResponse([
+                        'type' => 'server error',
+                        'message' => $e->getMessage(),
+                        'data' => $data,
+                    ]);
+                }
+
+                // Return server error response
+                return $this->apiResponse([
+                    'type' => 'server error'
+                ]);
+            }
         }
 
         return parent::render($request, $e);

--- a/src/Exceptions/LumenHandler.php
+++ b/src/Exceptions/LumenHandler.php
@@ -92,14 +92,14 @@ class LumenHandler extends ExceptionHandler
                 ]);
 
                 return $this->apiResponse([
-                    'status_code' => $e->getCode(),
+                    'status_code' => 500,
                     'message' => $e->getMessage(),
                     'data' => $data,
                 ]);
             }
 
             // Not found http exception OR Method not allowed http exception
-            if ($e instanceof NotFoundHttpException || $e instanceof MethodNotAllowedHttpException) {
+            if ($e instanceof NotFoundHttpException || $e instanceof MethodNotAllowedHttpException || $e instanceof ModelNotFoundException) {
                 return $this->apiNotFound();
             }
 


### PR DESCRIPTION
### Description

- Added handling for `ModelNotFoundException` in `Handler` and `LumenHandler` to return a "not found" response.
- Standardized error codes by setting `500` as the default status code for general exceptions to ensure consistency.
- Explicitly cast the `app.debug` configuration value to boolean for improved reliability in debug checks.
- Refactored exception handling logic by streamlining the `render` methods and consolidating logic for clearer JSON responses.
- Improved code maintainability and readability by reorganizing exception handling for both JSON requests and debug mode.

### Type of Change
- [x] Bug fix
- [x] Refactor
- 
### Related Issues
None provided.

### Test Updates
- Confirmed handling of `ModelNotFoundException` returns appropriate "not found" responses.
- Validated error codes for general exceptions.
- Tested debug mode behavior with consistent boolean parsing.
- Verified JSON response improvements for multiple scenarios.

### Checklist
- [ ] Documentation updated as needed