### PR TITLE
Add API response service and helper utilities

### DIFF
--- a/src/Facades/ApiResponse.php
+++ b/src/Facades/ApiResponse.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace MA\LaravelApiResponse\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class ApiResponse extends Facade
+{
+    /**
+     * @return string
+     */
+    protected static function getFacadeAccessor(): string
+    {
+        return 'lapi-response';
+    }
+}

--- a/src/Providers/APIResponseProvider.php
+++ b/src/Providers/APIResponseProvider.php
@@ -4,6 +4,7 @@ namespace MA\LaravelApiResponse\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use MA\LaravelApiResponse\Console\PublishErrorCodesEnumCommand;
+use MA\LaravelApiResponse\Services\APIResponseService;
 
 class APIResponseProvider extends ServiceProvider
 {
@@ -14,7 +15,9 @@ class APIResponseProvider extends ServiceProvider
      */
     public function register()
     {
-
+        $this->app->singleton('lapi-response', function () {
+            return new APIResponseService();
+        });
     }
 
     /**
@@ -25,9 +28,7 @@ class APIResponseProvider extends ServiceProvider
     public function boot()
     {
         if ($this->app->runningInConsole()) {
-            $this->publishes([
-                __DIR__ . '/../config/response.php' => config_path('response.php'),
-            ], 'lapi-response-config');
+            $this->mergeConfigFrom(__DIR__ . '/../config/response.php', 'lapi-response-config');
             $this->commands([
                 PublishErrorCodesEnumCommand::class,
             ]);

--- a/src/Services/APIResponseService.php
+++ b/src/Services/APIResponseService.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MA\LaravelApiResponse\Services;
+
+use MA\LaravelApiResponse\Traits\APIResponseTrait;
+
+class APIResponseService
+{
+    use APIResponseTrait;
+
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,7 +1,12 @@
 <?php
 
 use Illuminate\Container\Container;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Date;
+use MA\LaravelApiResponse\Facades\ApiResponse;
 
 if (!function_exists('now')) {
     /**
@@ -143,5 +148,182 @@ if (!function_exists('app_path')) {
     function app_path($path = '')
     {
         return app()->path($path);
+    }
+}
+
+if (!function_exists('apiOk')) {
+    /**
+     * Handle a successful API response.
+     *
+     * @param mixed|null $data
+     * @return \Illuminate\Http\JsonResponse
+     */
+    function apiOk(mixed $data = null)
+    {
+        return APIResponse::apiOk($data);
+    }
+}
+
+if (!function_exists('apiNotFound')) {
+    /**
+     * Handle an API not found response.
+     *
+     * @param array|string|null $errors Errors or messages describing the issue.
+     * @param bool $throw_exception Indicates if an exception should be thrown.
+     * @param string|int|UnitEnum|null $errorCode Custom error code associated with the response.
+     * @return \Illuminate\Http\JsonResponse
+     */
+    function apiNotFound(array|string|null $errors = null, bool $throw_exception = true, string|int|UnitEnum|null $errorCode = null)
+    {
+        return APIResponse::apiNotFound($errors, $throw_exception, $errorCode);
+    }
+}
+
+if (!function_exists('apiBadRequest')) {
+    /**
+     * Handle an API bad request response.
+     *
+     * @param array|string|null $errors The errors associated with the bad request.
+     * @param bool $throw_exception Whether to throw an exception for the bad request.
+     * @param string|int|\UnitEnum|null $errorCode A specific error code to associate with the bad request.
+     * @return \Illuminate\Http\JsonResponse
+     */
+    function apiBadRequest(array|string|null $errors = null, bool $throw_exception = true, string|int|UnitEnum|null $errorCode = null)
+    {
+        return APIResponse::apiBadRequest($errors, $throw_exception, $errorCode);
+    }
+}
+
+if (!function_exists('apiException')) {
+    /**
+     * Handle and generate an API exception response.
+     *
+     * @param array|string|null $errors List of errors or error message.
+     * @param bool $throw_exception Indicates whether to throw the exception.
+     * @param string|int|UnitEnum|null $errorCode Specific error code for the exception.
+     * @return \Illuminate\Http\JsonResponse
+     */
+    function apiException(array|string|null $errors = null, bool $throw_exception = true, string|int|UnitEnum|null $errorCode = null)
+    {
+        return APIResponse::apiException($errors, $throw_exception, $errorCode);
+    }
+}
+
+if (!function_exists('apiUnauthenticated')) {
+    /**
+     * Create an unauthenticated API response.
+     *
+     * @param array|string|null $message The error message or messages to include in the response.
+     * @param array|string|null $errors The specific error details to include in the response.
+     * @param string|int|UnitEnum|null $errorCode The error code to associate with the response.
+     * @return \Illuminate\Http\JsonResponse
+     */
+    function apiUnauthenticated(array|string|null $message = null, array|string $errors = null, string|int|UnitEnum|null $errorCode = null)
+    {
+        return APIResponse::apiUnauthenticated($message, $errors, $errorCode);
+    }
+}
+
+if (!function_exists('apiUnauthenticated')) {
+    /**
+     * Handle an unauthenticated API response with a forbidden status.
+     *
+     * @param array|string|null $message The error message or messages to include in the response.
+     * @param array|string|null $errors Specific error details to include in the response.
+     * @param string|int|\UnitEnum|null $errorCode The error code associated with the response.
+     * @return \Illuminate\Http\JsonResponse
+     */
+    function apiUnauthenticated(array|string|null $message = null, array|string $errors = null, string|int|UnitEnum|null $errorCode = null)
+    {
+        return APIResponse::apiForbidden($message, $errors, $errorCode);
+    }
+}
+
+if (!function_exists('apiForbidden')) {
+    /**
+     * Generate a response indicating that the requested API action is forbidden.
+     *
+     * @param array|string|null $message Optional message providing additional context about the forbidden action.
+     * @param array|string|null $errors Optional detailed error information.
+     * @param string|int|\UnitEnum|null $errorCode Optional error code associated with the forbidden response.
+     * @return \Illuminate\Http\JsonResponse
+     */
+    function apiForbidden(array|string|null $message = null, array|string $errors = null, string|int|UnitEnum|null $errorCode = null)
+    {
+        return APIResponse::apiForbidden($message, $errors, $errorCode);
+    }
+}
+
+if (!function_exists('apiPaginate')) {
+    /**
+     * Paginate data for API responses.
+     *
+     * @param \Illuminate\Pagination\LengthAwarePaginator|\Illuminate\Http\Resources\Json\AnonymousResourceCollection $pagination
+     * @param array $appends
+     * @param bool $reverse_data
+     * @return \Illuminate\Http\JsonResponse
+     */
+    function apiPaginate(LengthAwarePaginator|AnonymousResourceCollection $pagination, array $appends = [], bool $reverse_data = false)
+    {
+        return APIResponse::apiPaginate($pagination, $appends, $reverse_data);
+    }
+}
+
+if (!function_exists('apiValidate')) {
+    /**
+     * Validate input data using the provided rules and messages, with optional attribute names.
+     *
+     * @param array|\Illuminate\Http\Request $data The input data to be validated.
+     * @param array $rules The validation rules to apply to the data.
+     * @param array $messages Optional custom error messages.
+     * @param array $attributes Optional custom attribute names.
+     * @return \Illuminate\Http\JsonResponse
+     */
+    function apiValidate(array|Request $data, array $rules, array $messages = [], array $attributes = [])
+    {
+        return APIResponse::apiValidate($data, $rules, $messages, $attributes);
+    }
+}
+
+if (!function_exists('apiDD')) {
+    /**
+     * Dump and die the provided data using the API response format.
+     *
+     * @param mixed $data
+     * @return \Illuminate\Http\JsonResponse
+     */
+    function apiDD(mixed $data)
+    {
+        return APIResponse::apiDD($data);
+    }
+}
+
+if (!function_exists('apiStreamResponse')) {
+    /**
+     * Stream an API response using a generator.
+     *
+     * @param \Generator $generator The generator providing the streamable data.
+     * @param string|null $message An optional message to include in the response.
+     * @param int $statusCode The HTTP status code to use for the response.
+     * @return \Illuminate\Http\Response|\Symfony\Component\HttpFoundation\StreamedJsonResponse
+     */
+    function apiStreamResponse(Generator $generator, ?string $message = null, int $statusCode = Response::HTTP_OK)
+    {
+        return APIResponse::apiStreamResponse($generator, $message, $statusCode);
+    }
+}
+
+if (!function_exists('apiResponse')) {
+    /**
+     * Generate an API response.
+     *
+     * @param array|string|null $arg The argument used for the response, can be an array, string, or null.
+     * @param mixed $data The data to include in the response.
+     * @param array $guards An array of guards to apply to the response.
+     * @return \Illuminate\Http\Response|\Symfony\Component\HttpFoundation\StreamedJsonResponse
+     */
+    function apiResponse(array|string|null $arg = null, mixed $data = null, array $guards = [])
+    {
+        return APIResponse::apiResponse($arg, $data, $guards);
     }
 }


### PR DESCRIPTION
### Description

This pull request introduces the `APIResponseService` for standardized API response handling. Key enhancements include:

- `lapi-response` singleton binding within the service provider.
- A new `ApiResponse` facade for easier access.
- Utility helper functions for common API response scenarios.

These additions aim to improve reusability and consistency across the codebase.